### PR TITLE
Clean exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .DS_Store
 droneblocks/node_modules
+
+.idea

--- a/lib/camera.py
+++ b/lib/camera.py
@@ -64,6 +64,8 @@ class Camera(object):
         self.drone.is_recording_video = False
 
     def __del__(self):
-        self.vout.release()
-        self.cap.release()
+        if self.vout:
+            self.vout.release()
+        if self.cap:
+            self.cap.release()
 

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -49,6 +49,7 @@ class Telemetry(object):
                     break
 
         thread = threading.Thread(target=recv)
+        thread.setDaemon(True)
         thread.start()
     
     def parse_telemetry(self, data):

--- a/lib/udp.py
+++ b/lib/udp.py
@@ -34,6 +34,7 @@ class UDP(object):
                     break
 
         receive_thread = threading.Thread(target=recv)
+        receive_thread.setDaemon(True)
         receive_thread.start()
 
     # Loop and wait for a response


### PR DESCRIPTION
I was working through the "OpenCV, Python, and DroneBlocks for Tello Camera Control" course and noticed you had to ctrl-c twice to exit.

I took a look at why that might be the case and it looks like we need to set the threads to daemon threads.  After doing this it worked, but I also had to perform some None checks as well.

I also added '.idea' to the .gitignore so my pycharm artifacts will be be ignored.

